### PR TITLE
Added processing fields in pdb_conversions.csv

### DIFF
--- a/csv/pdb_conversions.csv
+++ b/csv/pdb_conversions.csv
@@ -142,7 +142,6 @@ sample.grid.pretreatment_type,_em_grid_pretreatment.type,
 sample.grid.pretreatment_time,_em_grid_pretreatment.time,
 sample.grid.pretreatment_pressure,_em_grid_pretreatment.pressure,
 sample.grid.pretreatment_atmosphere,_em_grid_pretreatment.atmosphere,
-,,
 processing.movies.dose_per_image,_em_image_recording.avg_electron_dose_per_image
 processing.micrographs.number_micrographs,_em_image_recording.num_real_images
 processing.volumes.vol_resolution,_em_3d_reconstruction.resolution


### PR DESCRIPTION
In this PR I have included in the added pdb_conversions.csv the following fields that can be mapped from the processing schema to the mmCIF dictionary:
- processing.movies.dose_per_image
- processing.micrographs.number_micrographs
- processing.volumes.vol_resolution